### PR TITLE
 Created a constants file and removed all constant literals used throughout code

### DIFF
--- a/src/main/java/org/onedatashare/server/controller/CancelController.java
+++ b/src/main/java/org/onedatashare/server/controller/CancelController.java
@@ -1,5 +1,6 @@
 package org.onedatashare.server.controller;
 
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.useraction.UserAction;
 import org.onedatashare.server.service.ResourceServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +27,7 @@ public class CancelController {
      */
     @PostMapping
     public Object cancel(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
-        String cookie = headers.getFirst("cookie");
+        String cookie = headers.getFirst(ODSConstants.COOKIE);
         return resourceService.cancel(cookie, userAction);
     }
 }

--- a/src/main/java/org/onedatashare/server/controller/CredController.java
+++ b/src/main/java/org/onedatashare/server/controller/CredController.java
@@ -2,6 +2,7 @@ package org.onedatashare.server.controller;
 
 
 import org.onedatashare.server.model.core.Credential;
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -32,7 +33,7 @@ public class CredController {
    */
   @GetMapping
   public Mono<Map<UUID, Credential>> listCredentials(@RequestHeader HttpHeaders headers, @RequestParam Map<String, String> queryParameters) {
-    return userService.getCredentials(headers.getFirst("cookie"));
+    return userService.getCredentials(headers.getFirst(ODSConstants.COOKIE));
   }
 
 }

--- a/src/main/java/org/onedatashare/server/controller/DeleteController.java
+++ b/src/main/java/org/onedatashare/server/controller/DeleteController.java
@@ -30,18 +30,18 @@ public class DeleteController {
 
   @PostMapping
   public Object delete(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
-    String cookie = headers.getFirst("cookie");
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
     if(userAction.getUri().contains(ODSConstants.DROPBOX_URI_SCHEME)) {
       if(userAction.getCredential() == null) {
         return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
       }
       else return dbxService.delete(cookie, userAction);
-    }else if("googledrive:/".equals(userAction.getType())) {
+    }else if(ODSConstants.DRIVE_URI_SCHEME.equals(userAction.getType())) {
       if(userAction.getCredential() == null) {
         return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
       }
       else return resourceService.delete(cookie, userAction);
-    }else if("gsiftp://".equals(userAction.getType())) {
+    }else if(ODSConstants.GRIDFTP_URI_SCHEME.equals(userAction.getType())) {
       if (userAction.getCredential() == null) {
         return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
       } else return gridService.delete(cookie, userAction);

--- a/src/main/java/org/onedatashare/server/controller/DeleteController.java
+++ b/src/main/java/org/onedatashare/server/controller/DeleteController.java
@@ -1,5 +1,6 @@
 package org.onedatashare.server.controller;
 
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.useraction.UserAction;
 import org.onedatashare.server.model.error.AuthenticationRequired;
 import org.onedatashare.server.service.DbxService;
@@ -30,7 +31,7 @@ public class DeleteController {
   @PostMapping
   public Object delete(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
     String cookie = headers.getFirst("cookie");
-    if(userAction.getUri().contains("dropbox://")) {
+    if(userAction.getUri().contains(ODSConstants.DROPBOX_URI_SCHEME)) {
       if(userAction.getCredential() == null) {
         return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
       }

--- a/src/main/java/org/onedatashare/server/controller/DeleteJobController.java
+++ b/src/main/java/org/onedatashare/server/controller/DeleteJobController.java
@@ -1,6 +1,7 @@
 package org.onedatashare.server.controller;
 
 import org.onedatashare.server.model.core.Job;
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.useraction.UserAction;
 import org.onedatashare.server.service.ResourceServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ public class DeleteJobController {
 
     @PostMapping
     public Mono<Job> restartJob(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction){
-        String cookie = headers.getFirst("cookie");
+        String cookie = headers.getFirst(ODSConstants.COOKIE);
         return resourceService.deleteJob(cookie, userAction);
     }
 }

--- a/src/main/java/org/onedatashare/server/controller/DownloadController.java
+++ b/src/main/java/org/onedatashare/server/controller/DownloadController.java
@@ -52,14 +52,14 @@ public class DownloadController {
 
     @PostMapping
     public Object download(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
-        String cookie = headers.getFirst("cookie");
+        String cookie = headers.getFirst(ODSConstants.COOKIE);
         if (userAction.getUri().startsWith(ODSConstants.DROPBOX_URI_SCHEME)) {
             return dbxService.getDownloadURL(cookie, userAction);
-        } else if ("googledrive:/".equals(userAction.getType())) {
+        } else if (ODSConstants.DRIVE_URI_SCHEME.equals(userAction.getType())) {
             if (userAction.getCredential() == null) {
                 return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
             } else return resourceService.download(cookie, userAction);
-        } else if (userAction.getUri().startsWith("ftp://")) {
+        } else if (userAction.getUri().startsWith(ODSConstants.FTP_URI_SCHEME)) {
 
             return vfsService.getDownloadURL(cookie, userAction);
         }
@@ -68,7 +68,7 @@ public class DownloadController {
 
     @RequestMapping(value = "/file", method = RequestMethod.GET)
     public Mono<ResponseEntity> getAcquisition(@RequestHeader HttpHeaders clientHttpHeaders) {
-        String cookie = clientHttpHeaders.getFirst("cookie");
+        String cookie = clientHttpHeaders.getFirst(ODSConstants.COOKIE);
 
         Map<String,String> map = new HashMap<String,String>();
         Set<Cookie> cookies = CookieDecoder.decode(cookie);

--- a/src/main/java/org/onedatashare/server/controller/DownloadController.java
+++ b/src/main/java/org/onedatashare/server/controller/DownloadController.java
@@ -6,6 +6,7 @@ import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.core.User;
 import org.onedatashare.server.model.error.AuthenticationRequired;
 import org.onedatashare.server.model.useraction.UserAction;
@@ -52,7 +53,7 @@ public class DownloadController {
     @PostMapping
     public Object download(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
         String cookie = headers.getFirst("cookie");
-        if (userAction.getUri().startsWith("dropbox://")) {
+        if (userAction.getUri().startsWith(ODSConstants.DROPBOX_URI_SCHEME)) {
             return dbxService.getDownloadURL(cookie, userAction);
         } else if ("googledrive:/".equals(userAction.getType())) {
             if (userAction.getCredential() == null) {

--- a/src/main/java/org/onedatashare/server/controller/GlobusEndpointController.java
+++ b/src/main/java/org/onedatashare/server/controller/GlobusEndpointController.java
@@ -3,6 +3,7 @@ package org.onedatashare.server.controller;
 import org.onedatashare.module.globusapi.EndPointList;
 import org.onedatashare.module.globusapi.GlobusClient;
 import org.onedatashare.server.model.core.Credential;
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.credential.OAuthCredential;
 import org.onedatashare.server.model.error.NotFound;
 import org.onedatashare.server.model.useraction.GlobusEndpointAction;
@@ -25,22 +26,22 @@ public class GlobusEndpointController {
     public Object globusRequest(@RequestHeader HttpHeaders headers, @RequestBody UserAction gea) {
         switch(gea.getAction()) {
             case "endpoint_list":
-                return userService.getGlobusClient(headers.getFirst("cookie")).flatMap(gc ->
+                return userService.getGlobusClient(headers.getFirst(ODSConstants.COOKIE)).flatMap(gc ->
                         gc.getEndPointList("all", "0", "100", gea.getFilter_fulltext()));
             case "endpoint":
-                return userService.getGlobusClient(headers.getFirst("cookie")).flatMap(gc ->
+                return userService.getGlobusClient(headers.getFirst(ODSConstants.COOKIE)).flatMap(gc ->
                         gc.getEndPoint(gea.getGlobusEndpoint().getId()));
             case "endpointId":
                 if(gea.getGlobusEndpoint().getId() == null){
-                    return userService.getEndpointId(headers.getFirst("Cookie"));
+                    return userService.getEndpointId(headers.getFirst(ODSConstants.COOKIE));
                 }
                 return userService.saveEndpointId(UUID.fromString(gea.getGlobusEndpoint().getId()),
-                                                  gea.getGlobusEndpoint(), headers.getFirst("Cookie")
+                                                  gea.getGlobusEndpoint(), headers.getFirst(ODSConstants.COOKIE)
                 );
             case "deleteEndpointId":
-                return userService.deleteEndpointId(headers.getFirst("Cookie"), UUID.fromString(gea.getGlobusEndpoint().getId()));
+                return userService.deleteEndpointId(headers.getFirst(ODSConstants.COOKIE), UUID.fromString(gea.getGlobusEndpoint().getId()));
             case "endpointActivate":
-                return userService.getGlobusClient(headers.getFirst("cookie")).flatMap(gc ->
+                return userService.getGlobusClient(headers.getFirst(ODSConstants.COOKIE)).flatMap(gc ->
                     gc.activateEndPoint(gea.getGlobusEndpoint().getId(), gea.getGlobusEndpoint().getMyProxyServer(),
                                         gea.getGlobusEndpoint().getMyProxyDomainName(), gea.getUsername(), gea.getPassword()))
                     .switchIfEmpty(Mono.error(new Exception("Auth Failed")));

--- a/src/main/java/org/onedatashare/server/controller/ListController.java
+++ b/src/main/java/org/onedatashare/server/controller/ListController.java
@@ -36,13 +36,13 @@ public class ListController {
 
   @PostMapping
   public Object list(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
-    String cookie = headers.getFirst("cookie");
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
 
     if(userAction.getCredential() == null) {
       switch (userAction.getType()) {
         case ODSConstants.DROPBOX_URI_SCHEME:
-        case "googledrive:/":
-        case "gsiftp://":
+        case ODSConstants.DRIVE_URI_SCHEME:
+        case ODSConstants.GRIDFTP_URI_SCHEME:
           return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
       }
     }
@@ -50,13 +50,13 @@ public class ListController {
     switch (userAction.getType()){
       case ODSConstants.DROPBOX_URI_SCHEME:
         return dbxService.list(cookie, userAction);
-      case "googledrive:/":
+      case ODSConstants.DRIVE_URI_SCHEME:
         return resourceService.list(cookie, userAction);
-      case "gsiftp://":
+      case ODSConstants.GRIDFTP_URI_SCHEME:
         return gridService.list(cookie, userAction);
-      case "scp://":
-      case "sftp://":
-      case "ftp://":
+      case ODSConstants.SCP_URI_SCHEME:
+      case ODSConstants.SFTP_URI_SCHEME:
+      case ODSConstants.FTP_URI_SCHEME:
         return vfsService.list(cookie, userAction);
       case "http://":
       default:

--- a/src/main/java/org/onedatashare/server/controller/ListController.java
+++ b/src/main/java/org/onedatashare/server/controller/ListController.java
@@ -1,6 +1,7 @@
 package org.onedatashare.server.controller;
 
 import org.apache.http.protocol.HttpService;
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.core.Stat;
 import org.onedatashare.server.model.useraction.UserAction;
 import org.onedatashare.server.model.error.AuthenticationRequired;
@@ -39,7 +40,7 @@ public class ListController {
 
     if(userAction.getCredential() == null) {
       switch (userAction.getType()) {
-        case "dropbox:///":
+        case ODSConstants.DROPBOX_URI_SCHEME:
         case "googledrive:/":
         case "gsiftp://":
           return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
@@ -47,7 +48,7 @@ public class ListController {
     }
 
     switch (userAction.getType()){
-      case "dropbox:///":
+      case ODSConstants.DROPBOX_URI_SCHEME:
         return dbxService.list(cookie, userAction);
       case "googledrive:/":
         return resourceService.list(cookie, userAction);

--- a/src/main/java/org/onedatashare/server/controller/MkdirController.java
+++ b/src/main/java/org/onedatashare/server/controller/MkdirController.java
@@ -31,18 +31,18 @@ public class MkdirController {
 
   @PostMapping
   public Object mkdir(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
-    String cookie = headers.getFirst("cookie");
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
     if(userAction.getUri().contains(ODSConstants.DROPBOX_URI_SCHEME)) {
       if(userAction.getCredential() == null) {
         return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
       }
       else return dbxService.mkdir(cookie, userAction);
-    }else if("googledrive:/".equals(userAction.getType())) {
+    }else if(ODSConstants.DRIVE_URI_SCHEME.equals(userAction.getType())) {
       if(userAction.getCredential() == null) {
         return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
       }
       else return resourceService.mkdir(cookie, userAction);
-    }else if("gsiftp://".equals(userAction.getType())) {
+    }else if(ODSConstants.GRIDFTP_URI_SCHEME.equals(userAction.getType())) {
       if (userAction.getCredential() == null) {
         return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
       } else return gridService.mkdir(cookie, userAction);

--- a/src/main/java/org/onedatashare/server/controller/MkdirController.java
+++ b/src/main/java/org/onedatashare/server/controller/MkdirController.java
@@ -1,5 +1,6 @@
 package org.onedatashare.server.controller;
 
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.useraction.UserAction;
 import org.onedatashare.server.model.error.AuthenticationRequired;
 import org.onedatashare.server.service.DbxService;
@@ -31,7 +32,7 @@ public class MkdirController {
   @PostMapping
   public Object mkdir(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
     String cookie = headers.getFirst("cookie");
-    if(userAction.getUri().contains("dropbox://")) {
+    if(userAction.getUri().contains(ODSConstants.DROPBOX_URI_SCHEME)) {
       if(userAction.getCredential() == null) {
         return new ResponseEntity<>(new AuthenticationRequired("oauth"), HttpStatus.INTERNAL_SERVER_ERROR);
       }

--- a/src/main/java/org/onedatashare/server/controller/OauthController.java
+++ b/src/main/java/org/onedatashare/server/controller/OauthController.java
@@ -1,5 +1,6 @@
 package org.onedatashare.server.controller;
 
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.error.DuplicateCredentialException;
 import org.onedatashare.server.service.ODSLoggerService;
 import org.onedatashare.server.service.oauth.GoogleDriveOauthService;
@@ -41,7 +42,7 @@ public class OauthController {
 
   @GetMapping(value = "/googledrive")
   public Object googledriveOauthFinish(@RequestHeader HttpHeaders headers, @RequestParam Map<String, String> queryParameters){
-    String cookie = headers.getFirst("cookie");
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
     return googleDriveOauthService.finish(queryParameters.get("code"), cookie)
             .flatMap(oauthCred -> userService.saveCredential(cookie, oauthCred))
             .map(uuid -> Rendering.redirectTo("/oauth/" + uuid).build())
@@ -50,7 +51,7 @@ public class OauthController {
 
   @GetMapping(value = "/dropbox")
   public Object dropboxOauthFinish(@RequestHeader HttpHeaders headers, @RequestParam Map<String, String> queryParameters){
-    String cookie = headers.getFirst("cookie");
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
     return dbxOauthService.finish(queryParameters.get("code"), cookie)
             .flatMap(oauthCred -> userService.saveCredential(cookie, oauthCred))
             .map(uuid -> Rendering.redirectTo("/oauth/" + uuid).build())
@@ -59,7 +60,7 @@ public class OauthController {
 
   @GetMapping(value = "/gridftp")
   public Object gridftpOauthFinish(@RequestHeader HttpHeaders headers, @RequestParam Map<String, String> queryParameters){
-    String cookie = headers.getFirst("cookie");
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
     return gridftpAuthService.finish(queryParameters.get("code"))
             .flatMap(oauthCred -> userService.saveCredential(cookie, oauthCred))
             .map(uuid -> Rendering.redirectTo("/oauth/" + uuid).build());
@@ -67,7 +68,7 @@ public class OauthController {
 
   @GetMapping
   public Object handle(@RequestHeader HttpHeaders headers, @RequestParam Map<String, String> queryParameters) {
-    String cookie = headers.getFirst("cookie");
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
 
       if(queryParameters.get("type").equals(googledrive) ){
         return userService.userLoggedIn(cookie)

--- a/src/main/java/org/onedatashare/server/controller/QueueController.java
+++ b/src/main/java/org/onedatashare/server/controller/QueueController.java
@@ -1,5 +1,6 @@
 package org.onedatashare.server.controller;
 
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.jobaction.JobRequest;
 import org.onedatashare.server.model.core.JobDetails;
 import org.onedatashare.server.service.JobService;
@@ -18,7 +19,7 @@ public class QueueController {
 
   @PostMapping
   public Mono<JobDetails> queue(@RequestHeader HttpHeaders headers, @RequestBody JobRequest jobDetails) {
-    String cookie = headers.getFirst("cookie");
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
     return jobService.getJobsForUserOrAdmin(cookie, jobDetails)
             .subscribeOn(Schedulers.elastic());
   }

--- a/src/main/java/org/onedatashare/server/controller/RestartJobController.java
+++ b/src/main/java/org/onedatashare/server/controller/RestartJobController.java
@@ -1,6 +1,7 @@
 package org.onedatashare.server.controller;
 
 import org.onedatashare.server.model.core.Job;
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.useraction.UserAction;
 import org.onedatashare.server.service.ResourceServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ public class RestartJobController {
 
     @PostMapping
     public Mono<Job> restartJob(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction){
-        String cookie = headers.getFirst("cookie");
+        String cookie = headers.getFirst(ODSConstants.COOKIE);
         return resourceService.restartJob(cookie, userAction);
     }
 }

--- a/src/main/java/org/onedatashare/server/controller/SubmitController.java
+++ b/src/main/java/org/onedatashare/server/controller/SubmitController.java
@@ -1,9 +1,8 @@
 package org.onedatashare.server.controller;
 
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.useraction.UserAction;
-import org.onedatashare.server.service.DbxService;
 import org.onedatashare.server.service.ResourceServiceImpl;
-import org.onedatashare.server.service.VfsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +16,7 @@ public class SubmitController {
 
   @PostMapping
   public Object submit(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
-    String cookie = headers.getFirst("cookie");
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
     return resourceService.submit(cookie, userAction);
   }
 }

--- a/src/main/java/org/onedatashare/server/controller/UploadController.java
+++ b/src/main/java/org/onedatashare/server/controller/UploadController.java
@@ -3,6 +3,7 @@ package org.onedatashare.server.controller;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import org.onedatashare.server.model.core.Credential;
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.useraction.UserAction;
 import org.onedatashare.server.service.UploadService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,20 +27,21 @@ public class UploadController {
     public Mono<Object> upload(@RequestHeader HttpHeaders headers,
                                @RequestPart("directoryPath") String directoryPath,
                                @RequestPart("qqfilename") String fileName,
-                               @RequestPart("map") String idmap,
+                               @RequestPart("map") String idMap,
                                @RequestPart("credential") String credential,
                                @RequestPart("id") String googledriveid,
                                @RequestPart("qquuid") String fileUUID,
                                @RequestPart("qqtotalfilesize") String totalFileSize,
                                @RequestPart("qqfile") Mono<FilePart> filePart){
-        String cookie = headers.getFirst("cookie");
-        if(directoryPath.startsWith("scp://")){
-            directoryPath = "sftp://" + directoryPath.substring(6);
-            idmap.replace("scp://","sftp://");
+
+        String cookie = headers.getFirst(ODSConstants.COOKIE);
+        if(directoryPath.startsWith(ODSConstants.SCP_URI_SCHEME)){
+            directoryPath = directoryPath.replace(ODSConstants.SCP_URI_SCHEME, ODSConstants.SFTP_URI_SCHEME);
+            idMap = idMap.replace(ODSConstants.SCP_URI_SCHEME, ODSConstants.SFTP_URI_SCHEME);
         }
         return uploadService.uploadChunk(cookie, UUID.fromString(fileUUID),
             filePart, credential, directoryPath, fileName,
-            Long.parseLong(totalFileSize), googledriveid, idmap).map(job -> {
+            Long.parseLong(totalFileSize), googledriveid, idMap).map(job -> {
                 FineUploaderResponse resp = new FineUploaderResponse();
                 resp.success = true;
                 return resp;

--- a/src/main/java/org/onedatashare/server/controller/UserController.java
+++ b/src/main/java/org/onedatashare/server/controller/UserController.java
@@ -1,5 +1,6 @@
 package org.onedatashare.server.controller;
 
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.error.ForbiddenAction;
 import org.onedatashare.server.model.error.InvalidField;
 import org.onedatashare.server.model.error.NotFound;
@@ -23,37 +24,41 @@ public class UserController {
   @PostMapping
   public Object performAction(@RequestHeader HttpHeaders headers, @RequestBody UserAction userAction) {
 
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
     switch(userAction.getAction()) {
       case "login":
         return userService.login(userAction.getEmail(), userAction.getPassword());
       case "register":
-        return userService.register(userAction.getEmail(), userAction.getFirstName(), userAction.getLastName(), userAction.getOrganization());
+        return userService.register(userAction.getEmail(), userAction.getFirstName(), userAction.getLastName(),
+                                      userAction.getOrganization());
       case "validate":
         return userService.validate(userAction.getEmail(), userAction.getCode());
       case "history":
-        return userService.saveHistory(userAction.getUri(), headers.getFirst("Cookie"));
+        return userService.saveHistory(userAction.getUri(), cookie);
       case "verifyEmail":
         return userService.verifyEmail(userAction.getEmail());
       case "sendVerificationCode":
         return userService.sendVerificationCode(userAction.getEmail(), TIMEOUT_IN_MINUTES);
       case "getUser":
-        return userService.getUserFromCookie(userAction.getEmail(), headers.getFirst("Cookie"));
+        return userService.getUserFromCookie(userAction.getEmail(), cookie);
       case "getUsers":
-        return userService.getAllUsers(userAction, headers.getFirst("Cookie"));
+        return userService.getAllUsers(userAction, headers.getFirst(ODSConstants.COOKIE));
       case "getAdministrators":
-        return userService.getAdministrators(userAction, headers.getFirst("Cookie"));
+        return userService.getAdministrators(userAction, cookie);
       case "verifyCode":
         return userService.verifyCode(userAction.getEmail(), userAction.getCode());
       case "setPassword":
-        return userService.resetPassword(userAction.getEmail(), userAction.getPassword(), userAction.getConfirmPassword(), userAction.getCode());
+        return userService.resetPassword(userAction.getEmail(), userAction.getPassword(), userAction.getConfirmPassword(),
+                                          userAction.getCode());
       case "resetPassword":
-        return userService.resetPasswordWithOld(headers.getFirst("Cookie"), userAction.getPassword(), userAction.getNewPassword(), userAction.getConfirmPassword());
+        return userService.resetPasswordWithOld(cookie, userAction.getPassword(), userAction.getNewPassword(),
+                                                  userAction.getConfirmPassword());
       case "deleteCredential":
-        return userService.deleteCredential(headers.getFirst("Cookie"), userAction.getUuid());
+        return userService.deleteCredential(cookie, userAction.getUuid());
       case "deleteHistory":
-        return userService.deleteHistory(headers.getFirst("Cookie"), userAction.getUri());
+        return userService.deleteHistory(cookie, userAction.getUri());
       case "isAdmin":
-        return userService.isAdmin(headers.getFirst("cookie"));
+        return userService.isAdmin(cookie);
       case "resendVerificationCode":
         return userService.resendVerificationCode(userAction.getEmail());
       default:
@@ -77,7 +82,7 @@ public class UserController {
 
   @GetMapping
   public Object getHistory(@RequestHeader HttpHeaders headers) {
-    return userService.getHistory(headers.getFirst("Cookie"));
+    return userService.getHistory(headers.getFirst(ODSConstants.COOKIE));
   }
 
   @ExceptionHandler(InvalidField.class)

--- a/src/main/java/org/onedatashare/server/model/core/ODSConstants.java
+++ b/src/main/java/org/onedatashare/server/model/core/ODSConstants.java
@@ -1,0 +1,4 @@
+package org.onedatashare.server.model.core;
+
+public class ODSConstants {
+}

--- a/src/main/java/org/onedatashare/server/model/core/ODSConstants.java
+++ b/src/main/java/org/onedatashare/server/model/core/ODSConstants.java
@@ -2,13 +2,16 @@ package org.onedatashare.server.model.core;
 
 public class ODSConstants {
 
-    public static final String DROPBOX_URI_SCHEME = "dropbox://";
+    public static final String DROPBOX_URI_SCHEME = "dropbox:///";
     public static final String DRIVE_URI_SCHEME = "googledrive:/";
     public static final String SFTP_URI_SCHEME = "sftp://";
-    public static final String FTP_URI_SCHEME = "sftp://";
+    public static final String FTP_URI_SCHEME = "ftp://";
     public static final String SCP_URI_SCHEME = "scp://";
+    public static final String GRIDFTP_URI_SCHEME = "gsiftp://";
 
     public static final String UPLOAD_IDENTIFIER = "Upload";
+
+    public static final String COOKIE = "cookie";
 
 
 }

--- a/src/main/java/org/onedatashare/server/model/core/ODSConstants.java
+++ b/src/main/java/org/onedatashare/server/model/core/ODSConstants.java
@@ -1,4 +1,14 @@
 package org.onedatashare.server.model.core;
 
 public class ODSConstants {
+
+    public static final String DROPBOX_URI_SCHEME = "dropbox://";
+    public static final String DRIVE_URI_SCHEME = "googledrive:/";
+    public static final String SFTP_URI_SCHEME = "sftp://";
+    public static final String FTP_URI_SCHEME = "sftp://";
+    public static final String SCP_URI_SCHEME = "scp://";
+
+    public static final String UPLOAD_IDENTIFIER = "Upload";
+
+
 }

--- a/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
+++ b/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
@@ -294,7 +294,7 @@ public class VfsResource extends Resource<VfsSession, VfsResource> {
         StringBuilder downloadURL = new StringBuilder();
 
         if (username != null)
-            downloadURL.append("ftp://" + username + ':' + password + '@' + downloadLink.substring(6));
+            downloadURL.append(ODSConstants.FTP_URI_SCHEME + username + ':' + password + '@' + downloadLink.substring(6));
         else
             downloadURL.append(downloadLink);
         downloadLink = downloadURL.toString();

--- a/src/main/java/org/onedatashare/server/service/DbxService.java
+++ b/src/main/java/org/onedatashare/server/service/DbxService.java
@@ -47,7 +47,7 @@ public class DbxService implements ResourceService<DbxResource>{
   public String pathFromDbxUri(String uri) {
     String path = "";
     if(uri.contains(ODSConstants.DROPBOX_URI_SCHEME)){
-      path = uri.split(ODSConstants.DROPBOX_URI_SCHEME)[1];
+      path = uri.substring(ODSConstants.DROPBOX_URI_SCHEME.length() - 1);
     }
     try {
       path = java.net.URLDecoder.decode(path, "UTF-8");

--- a/src/main/java/org/onedatashare/server/service/DbxService.java
+++ b/src/main/java/org/onedatashare/server/service/DbxService.java
@@ -46,8 +46,8 @@ public class DbxService implements ResourceService<DbxResource>{
 
   public String pathFromDbxUri(String uri) {
     String path = "";
-    if(uri.contains("dropbox://")){
-      path = uri.split("dropbox://")[1];
+    if(uri.contains(ODSConstants.DROPBOX_URI_SCHEME)){
+      path = uri.split(ODSConstants.DROPBOX_URI_SCHEME)[1];
     }
     try {
       path = java.net.URLDecoder.decode(path, "UTF-8");

--- a/src/main/java/org/onedatashare/server/service/GridftpService.java
+++ b/src/main/java/org/onedatashare/server/service/GridftpService.java
@@ -2,6 +2,7 @@
 package org.onedatashare.server.service;
 
 import org.onedatashare.module.globusapi.Result;
+import org.onedatashare.server.model.core.ODSConstants;
 import org.onedatashare.server.model.core.Stat;
 import org.onedatashare.server.model.credential.GlobusWebClientCredential;
 import org.onedatashare.server.model.credential.UserInfoCredential;
@@ -51,8 +52,8 @@ public class GridftpService {
 
     public static String pathFromUri(String uri) {
         String path;
-        if(uri.contains("gsiftp://")){
-            path = uri.split("gsiftp://")[1];
+        if(uri.contains(ODSConstants.GRIDFTP_URI_SCHEME)){
+            path = uri.substring(ODSConstants.GRIDFTP_URI_SCHEME.length());
         }
         else path = uri;
         try {

--- a/src/main/java/org/onedatashare/server/service/ResourceServiceImpl.java
+++ b/src/main/java/org/onedatashare/server/service/ResourceServiceImpl.java
@@ -74,8 +74,8 @@ public class ResourceServiceImpl implements ResourceService<Resource>  {
 
     public String pathFromUri(String uri) {
         String path = "";
-        if(uri.contains("dropbox://")){
-            path = uri.split("dropbox://")[1];
+        if(uri.contains(ODSConstants.DROPBOX_URI_SCHEME)){
+            path = uri.split(ODSConstants.DROPBOX_URI_SCHEME)[1];
         }else if(uri.contains("googledrive:/")){
             path = uri.split("googledrive:")[1];
         }else path = uri;
@@ -89,7 +89,7 @@ public class ResourceServiceImpl implements ResourceService<Resource>  {
     }
 
     public Credential createCredential(UserActionResource userActionResource, User user) {
-        if(userActionResource.getUri().contains("dropbox://") || userActionResource.getUri().contains("googledrive:/")){
+        if(userActionResource.getUri().contains(ODSConstants.DROPBOX_URI_SCHEME) || userActionResource.getUri().contains("googledrive:/")){
             return user.getCredentials().get(UUID.fromString(userActionResource.getCredential().getUuid()));
         }else if(userActionResource.getUri().equals("Upload")){
             return userActionResource.getUploader();
@@ -103,7 +103,7 @@ public class ResourceServiceImpl implements ResourceService<Resource>  {
 
 
     public Session createSession(String uri, Credential credential) {
-        if(uri.contains("dropbox://")){
+        if(uri.contains(ODSConstants.DROPBOX_URI_SCHEME)){
             return new DbxSession(URI.create(uri), credential);
         }else if(uri.contains("Upload")){
             UploadCredential upc = (UploadCredential)credential;

--- a/src/main/java/org/onedatashare/server/service/ResourceServiceImpl.java
+++ b/src/main/java/org/onedatashare/server/service/ResourceServiceImpl.java
@@ -75,9 +75,9 @@ public class ResourceServiceImpl implements ResourceService<Resource>  {
     public String pathFromUri(String uri) {
         String path = "";
         if(uri.contains(ODSConstants.DROPBOX_URI_SCHEME)){
-            path = uri.split(ODSConstants.DROPBOX_URI_SCHEME)[1];
-        }else if(uri.contains("googledrive:/")){
-            path = uri.split("googledrive:")[1];
+            path = uri.substring(ODSConstants.DROPBOX_URI_SCHEME.length() - 1);
+        }else if(uri.contains(ODSConstants.DRIVE_URI_SCHEME)){
+            path = uri.substring(ODSConstants.DRIVE_URI_SCHEME.length() - 1);
         }else path = uri;
 
         try {
@@ -89,11 +89,12 @@ public class ResourceServiceImpl implements ResourceService<Resource>  {
     }
 
     public Credential createCredential(UserActionResource userActionResource, User user) {
-        if(userActionResource.getUri().contains(ODSConstants.DROPBOX_URI_SCHEME) || userActionResource.getUri().contains("googledrive:/")){
+        if(userActionResource.getUri().contains(ODSConstants.DROPBOX_URI_SCHEME) ||
+                userActionResource.getUri().contains(ODSConstants.DRIVE_URI_SCHEME)){
             return user.getCredentials().get(UUID.fromString(userActionResource.getCredential().getUuid()));
-        }else if(userActionResource.getUri().equals("Upload")){
+        }else if(userActionResource.getUri().equals(ODSConstants.UPLOAD_IDENTIFIER)){
             return userActionResource.getUploader();
-        }else if(userActionResource.getUri().startsWith("gsiftp://")){
+        }else if(userActionResource.getUri().startsWith(ODSConstants.GRIDFTP_URI_SCHEME)){
 
             GlobusClient gc = userService.getGlobusClientFromUser(user);
             return new GlobusWebClientCredential(userActionResource.getCredential().getGlobusEndpoint(), gc);
@@ -105,10 +106,10 @@ public class ResourceServiceImpl implements ResourceService<Resource>  {
     public Session createSession(String uri, Credential credential) {
         if(uri.contains(ODSConstants.DROPBOX_URI_SCHEME)){
             return new DbxSession(URI.create(uri), credential);
-        }else if(uri.contains("Upload")){
+        }else if(uri.contains(ODSConstants.UPLOAD_IDENTIFIER)){
             UploadCredential upc = (UploadCredential)credential;
             return new ClientUploadSession(upc.getFux(), upc.getSize(), upc.getName());
-        }else if(uri.contains("googledrive:/")){
+        }else if(uri.contains(ODSConstants.DRIVE_URI_SCHEME)){
             return new GoogleDriveSession(URI.create(uri), credential);
         }else if(credential instanceof GlobusWebClientCredential){
             return new GridftpSession(URI.create(uri), credential);

--- a/src/main/java/org/onedatashare/server/service/UploadService.java
+++ b/src/main/java/org/onedatashare/server/service/UploadService.java
@@ -40,10 +40,10 @@ public class UploadService {
         else {
             UserAction ua = new UserAction();
             ua.setSrc(new UserActionResource());
-            ua.getSrc().setUri("Upload");
+            ua.getSrc().setUri(ODSConstants.UPLOAD_IDENTIFIER);
             LinkedBlockingQueue<Slice> uploadQueue = new LinkedBlockingQueue<Slice>();
             ua.getSrc().setUploader( new UploadCredential(uploadQueue, totalFileSize, fileName) );
-            ODSLoggerService.logInfo("total "+totalFileSize);
+            ODSLoggerService.logInfo("Total upload file size - " + totalFileSize);
             ua.setDest( new UserActionResource());
             ua.getDest().setId( googleDriveId );
 

--- a/src/main/java/org/onedatashare/server/service/VfsService.java
+++ b/src/main/java/org/onedatashare/server/service/VfsService.java
@@ -115,23 +115,23 @@ public class VfsService implements ResourceService<VfsResource> {
     }
 
     public void fixSCPUri(UserAction userAction){
-        if(userAction.getType().equals("scp://")){
-            userAction.setType("sftp://");
-            userAction.setUri("sftp://" + userAction.getUri().substring(6));
+        if(userAction.getType().equals(ODSConstants.SCP_URI_SCHEME)){
+            userAction.setType(ODSConstants.SFTP_URI_SCHEME);
+            userAction.setUri(ODSConstants.SFTP_URI_SCHEME + userAction.getUri().substring(6));
         }
     }
 
     public void fixSCPUri(UserActionResource userAction){
-        if(userAction.getType().equals("scp://")){
-            userAction.setType( "sftp://" );
-            userAction.setUri( "sftp://" + userAction.getUri().substring(FTP_URL_OFFSET) );
+        if(userAction.getType().equals(ODSConstants.SCP_URI_SCHEME)){
+            userAction.setType(ODSConstants.SFTP_URI_SCHEME);
+            userAction.setUri( ODSConstants.SFTP_URI_SCHEME + userAction.getUri().substring(FTP_URL_OFFSET) );
         }
     }
 
     public String pathFromUri(String uri) {
         String path = "";
         if (uri.contains(ODSConstants.DROPBOX_URI_SCHEME)) {
-            path = uri.split(ODSConstants.DROPBOX_URI_SCHEME)[1];
+            path = uri.substring(ODSConstants.DROPBOX_URI_SCHEME.length() - 1);
         } else path = uri;
         try {
             path = java.net.URLDecoder.decode(path, "UTF-8");

--- a/src/main/java/org/onedatashare/server/service/VfsService.java
+++ b/src/main/java/org/onedatashare/server/service/VfsService.java
@@ -130,8 +130,8 @@ public class VfsService implements ResourceService<VfsResource> {
 
     public String pathFromUri(String uri) {
         String path = "";
-        if (uri.contains("dropbox://")) {
-            path = uri.split("dropbox://")[1];
+        if (uri.contains(ODSConstants.DROPBOX_URI_SCHEME)) {
+            path = uri.split(ODSConstants.DROPBOX_URI_SCHEME)[1];
         } else path = uri;
         try {
             path = java.net.URLDecoder.decode(path, "UTF-8");


### PR DESCRIPTION
Practice follows industry standards, improves code readability, provides a central location for all constant values and avoids spelling errors in usage of literals 