### PR TITLE
Fixed larger than 2gb file transfer from FTP to Dropbox

### DIFF
--- a/src/main/java/org/onedatashare/server/module/http/HttpResource.java
+++ b/src/main/java/org/onedatashare/server/module/http/HttpResource.java
@@ -294,7 +294,7 @@ public class HttpResource extends Resource<HttpSession, HttpResource> {
          */
         public Flux<Slice> tap(long sliceSize) {
             int sliceSizeInt = Math.toIntExact(sliceSize);
-            int sizeInt = Math.toIntExact(size);
+            long sizeInt = size;
             InputStream inputStream = null;
             try {
                 inputStream = fileContent.getInputStream();
@@ -316,7 +316,7 @@ public class HttpResource extends Resource<HttpSession, HttpResource> {
                             }
                             sink.next(new Slice(b));
                         } else {
-                            int remaining = sizeInt - state;
+                            int remaining =  Math.toIntExact(sizeInt - state);
                             byte[] b = new byte[remaining];
                             try {
                                 // Fix for buggy PDF files - Else the PDF files are corrupted

--- a/src/main/java/org/onedatashare/server/module/http/HttpResource.java
+++ b/src/main/java/org/onedatashare/server/module/http/HttpResource.java
@@ -294,7 +294,6 @@ public class HttpResource extends Resource<HttpSession, HttpResource> {
          */
         public Flux<Slice> tap(long sliceSize) {
             int sliceSizeInt = Math.toIntExact(sliceSize);
-            long sizeInt = size;
             InputStream inputStream = null;
             try {
                 inputStream = fileContent.getInputStream();
@@ -305,7 +304,7 @@ public class HttpResource extends Resource<HttpSession, HttpResource> {
             return Flux.generate(
                     () -> 0,
                     (state, sink) -> {
-                        if (state + sliceSizeInt < sizeInt) {
+                        if (state + sliceSizeInt < size) {
                             byte[] b = new byte[sliceSizeInt];
                             try {
                                 // Fix for buggy PDF files - Else the PDF files are corrupted
@@ -316,7 +315,7 @@ public class HttpResource extends Resource<HttpSession, HttpResource> {
                             }
                             sink.next(new Slice(b));
                         } else {
-                            int remaining =  Math.toIntExact(sizeInt - state);
+                            int remaining =  Math.toIntExact(size - state);
                             byte[] b = new byte[remaining];
                             try {
                                 // Fix for buggy PDF files - Else the PDF files are corrupted

--- a/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
+++ b/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
@@ -198,7 +198,7 @@ public class VfsResource extends Resource<VfsSession, VfsResource> {
 
         public Flux<Slice> tap(long sliceSize) {
             int sliceSizeInt = Math.toIntExact(sliceSize);
-            int sizeInt = Math.toIntExact(size);
+            long sizeInt = size;
             InputStream inputStream = null;
             try {
                 inputStream = fileContent.getInputStream();
@@ -220,7 +220,7 @@ public class VfsResource extends Resource<VfsSession, VfsResource> {
                             }
                             sink.next(new Slice(b));
                         } else {
-                            int remaining = sizeInt - state;
+                            int remaining = Math.toIntExact(sizeInt - state);
                             byte[] b = new byte[remaining];
                             try {
                                 // Fix for buggy PDF files - Else the PDF files are corrupted

--- a/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
+++ b/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
@@ -198,7 +198,6 @@ public class VfsResource extends Resource<VfsSession, VfsResource> {
 
         public Flux<Slice> tap(long sliceSize) {
             int sliceSizeInt = Math.toIntExact(sliceSize);
-            long sizeInt = size;
             InputStream inputStream = null;
             try {
                 inputStream = fileContent.getInputStream();
@@ -209,7 +208,7 @@ public class VfsResource extends Resource<VfsSession, VfsResource> {
             return Flux.generate(
                     () -> 0,
                     (state, sink) -> {
-                        if (state + sliceSizeInt < sizeInt) {
+                        if (state + sliceSizeInt < size) {
                             byte[] b = new byte[sliceSizeInt];
                             try {
                                 // Fix for buggy PDF files - Else the PDF files are corrupted
@@ -220,7 +219,7 @@ public class VfsResource extends Resource<VfsSession, VfsResource> {
                             }
                             sink.next(new Slice(b));
                         } else {
-                            int remaining = Math.toIntExact(sizeInt - state);
+                            int remaining = Math.toIntExact(size - state);
                             byte[] b = new byte[remaining];
                             try {
                                 // Fix for buggy PDF files - Else the PDF files are corrupted


### PR DESCRIPTION
Tested on FTP to Dropbox
Seems like all transfer to Google drive is broken because of the last update. 