### PR TITLE
Oauth preference toggle

### DIFF
--- a/src/main/java/org/onedatashare/server/controller/CredController.java
+++ b/src/main/java/org/onedatashare/server/controller/CredController.java
@@ -37,8 +37,15 @@ public class CredController {
     return userService.getCredentials(headers.getFirst(ODSConstants.COOKIE));
   }
 
+  /**
+   * Handler for the POST request for saving the OAuth Credentials once the user toggles it in account preferences
+   * to save it.
+   * @param headers - Request header
+   * @param credentials - List of Credentials to save
+   * @return
+   */
   @PostMapping("/saveCredentials")
-  public Mono<Map<UUID, Credential>> saveCredentials(@RequestHeader HttpHeaders headers, @RequestBody List<OAuthCredential> credentials){
+  public Mono<Void> saveCredentials(@RequestHeader HttpHeaders headers, @RequestBody List<OAuthCredential> credentials){
     String cookie = headers.getFirst(ODSConstants.COOKIE);
     return userService.saveUserCredentials(cookie,credentials);
   }

--- a/src/main/java/org/onedatashare/server/controller/CredController.java
+++ b/src/main/java/org/onedatashare/server/controller/CredController.java
@@ -3,12 +3,14 @@ package org.onedatashare.server.controller;
 
 import org.onedatashare.server.model.core.Credential;
 import org.onedatashare.server.model.core.ODSConstants;
+import org.onedatashare.server.model.credential.OAuthCredential;
 import org.onedatashare.server.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -33,6 +35,12 @@ public class CredController {
   @GetMapping
   public Mono<Map<UUID, Credential>> listCredentials(@RequestHeader HttpHeaders headers) {
     return userService.getCredentials(headers.getFirst(ODSConstants.COOKIE));
+  }
+
+  @PostMapping("/saveCredentials")
+  public Mono<Map<UUID, Credential>> saveCredentials(@RequestHeader HttpHeaders headers, @RequestBody List<OAuthCredential> credentials){
+    String cookie = headers.getFirst(ODSConstants.COOKIE);
+    return userService.saveUserCredentials(cookie,credentials);
   }
 
 }

--- a/src/main/java/org/onedatashare/server/service/UserService.java
+++ b/src/main/java/org/onedatashare/server/service/UserService.java
@@ -388,6 +388,19 @@ public class UserService {
             .map(user -> uuid);
   }
 
+
+public Mono<Map<UUID, Credential>> saveUserCredentials(String cookie, List<OAuthCredential> credentials) {
+    return getLoggedInUser(cookie)
+            .map(user -> {
+                for(OAuthCredential credential : credentials) {
+                    final UUID uuid = UUID.randomUUID();
+                    user.getCredentials().put(uuid, credential);
+                }
+                return user;
+            })
+            .flatMap(userRepository::save).map(user -> user.getCredentials());
+}
+
   public Mono<Void> saveLastActivity(String email, Long lastActivity) {
     return getUser(email).doOnSuccess(user -> {
            user.setLastActivity(lastActivity);

--- a/src/main/java/org/onedatashare/server/service/UserService.java
+++ b/src/main/java/org/onedatashare/server/service/UserService.java
@@ -388,8 +388,13 @@ public class UserService {
             .map(user -> uuid);
   }
 
-
-public Mono<Map<UUID, Credential>> saveUserCredentials(String cookie, List<OAuthCredential> credentials) {
+    /**
+     * Saves the OAuth Credentials in user collection when the user toggles the preference button.
+     * @param cookie Browser cookie string passed in the HTTP request to the controller
+     * @param credentials The list of Oauth Credentials
+     * @return
+     */
+    public Mono<Void> saveUserCredentials(String cookie, List<OAuthCredential> credentials) {
     return getLoggedInUser(cookie)
             .map(user -> {
                 for(OAuthCredential credential : credentials) {
@@ -398,7 +403,7 @@ public Mono<Map<UUID, Credential>> saveUserCredentials(String cookie, List<OAuth
                 }
                 return user;
             })
-            .flatMap(userRepository::save).map(user -> user.getCredentials());
+            .flatMap(userRepository::save).then();
 }
 
   public Mono<Void> saveLastActivity(String email, Long lastActivity) {

--- a/src/main/react-front-end/src/APICalls/APICalls.js
+++ b/src/main/react-front-end/src/APICalls/APICalls.js
@@ -147,7 +147,7 @@ export async function resendVerificationCode(emailId){
 		return response
 	})
 	.catch((error) =>{
-		
+
 	});
 }
 
@@ -192,7 +192,7 @@ export async function login(email, password, accept, fail){
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
@@ -209,7 +209,7 @@ export async function isAdmin(email, hash, accept, fail){
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
@@ -326,7 +326,7 @@ export async function savedCredList(accept, fail){
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
@@ -402,7 +402,7 @@ export async function submit(src, srcEndpoint, dest, destEndpoint, options,accep
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
@@ -445,7 +445,7 @@ export async function share(uri, endpoint, accept, fail){
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
@@ -486,7 +486,7 @@ export async function deleteCall(uri, endpoint, id, accept, fail){
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
@@ -536,7 +536,7 @@ export async function getDownload(uri, credential, _id, succeed){
 		uri: encodeURI(uri),
 		id: "",
 	}
-	
+
 	const strin = JSON.stringify(json_to_send);
 	cookies.set("SFTPAUTH", strin, { expires : 10});
 
@@ -557,7 +557,7 @@ export async function upload(uri, credential, accept, fail){
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
@@ -581,7 +581,7 @@ export async function getUsers(type, pageNo, pageSize, sortBy, order, accept, fa
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
@@ -618,6 +618,20 @@ export async function updateSaveOAuth(email, saveOAuth, successCallback){
 	});
 }
 
+export async function saveOAuthCredentials(credentials,accept, fail){
+	var callback = accept;
+  console.log(credentials);
+	axios.post(url+'cred/saveCredentials', credentials)
+	.then((response) => {
+		if(!(response.status === 200))
+			callback = fail;
+		statusHandle(response, callback);
+	})
+	.catch((error) => {
+      fail(error);
+    });
+}
+
 export async function updateAdminRightsApiCall(email, isAdmin){
 	return axios.put(url+'user', {
 		action: "updateAdminRights",
@@ -644,7 +658,7 @@ export async function changePassword(oldPassword, newPassword,confirmPassword, a
 
 	axios.post(url+'user', {
 		action: "resetPassword",
-	    password: oldPassword, 
+	    password: oldPassword,
 	    newPassword: newPassword,
 	    confirmPassword: confirmPassword
 
@@ -672,7 +686,7 @@ export async function cancelJob(jobID, accept, fail){
 	  }),
 	})
 	.then((response) => {
-		if(!response.ok) 
+		if(!response.ok)
 			callback = fail;
 		statusHandle(response, callback);
 	})
@@ -710,7 +724,7 @@ export async function restartJob(jobID, accept, fail){
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
@@ -801,8 +815,7 @@ export async function globusListEndpoints( filter_fulltext, accept, fail) {
 		statusHandle(response, callback);
 	})
 	.catch((error) => {
-      
+
       statusHandle(error, fail);
     });
 }
-

--- a/src/main/react-front-end/src/APICalls/APICalls.js
+++ b/src/main/react-front-end/src/APICalls/APICalls.js
@@ -618,9 +618,16 @@ export async function updateSaveOAuth(email, saveOAuth, successCallback){
 	});
 }
 
+/*
+	Desc: Call the backend to save the OAuth Credentials when the user toggles
+        the button in account preferences to save credentials
+	input: Array of OAuth credentials
+	accept: (successMessage:string){}
+	fail: (errorMessage:string){}
+*/
+
 export async function saveOAuthCredentials(credentials,accept, fail){
 	var callback = accept;
-  console.log(credentials);
 	axios.post(url+'cred/saveCredentials', credentials)
 	.then((response) => {
 		if(!(response.status === 200))

--- a/src/main/react-front-end/src/views/Login/UserAccountComponent.js
+++ b/src/main/react-front-end/src/views/Login/UserAccountComponent.js
@@ -32,7 +32,8 @@ import { transferPageUrl, userPageUrl } from "../../constants";
 import {
 	changePassword,
 	getUser,
-	updateSaveOAuth
+	updateSaveOAuth,
+	saveOAuthCredentials
 } from "../../APICalls/APICalls";
 import { eventEmitter, store } from "../../App.js";
 
@@ -138,6 +139,22 @@ export default class UserAccountComponent extends Component {
 			if (currentSaveStatus) {
 				// if the user opted to switch from saving tokens on browser to
 				// storing tokens on the server, we clear all saved tokens in the current browser session.
+				let credentials = []
+				if(!(typeof cookies.get(GOOGLEDRIVE_NAME) == "undefined")){
+					var googleDriveCredentials = JSON.parse(cookies.get(GOOGLEDRIVE_NAME));
+					googleDriveCredentials.forEach(function(element){
+						element.name = "GoogleDrive: " + element.name;
+					});
+					credentials.push(...googleDriveCredentials);
+				}
+				if(!(typeof cookies.get(DROPBOX_NAME) == "undefined")){
+					var dropBoxCredentials = JSON.parse(cookies.get(DROPBOX_NAME));
+					dropBoxCredentials.forEach(function(element){
+						element.name = "Dropbox: " + element.name;
+					});
+					credentials.push(...dropBoxCredentials);
+				}
+				saveOAuthCredentials(credentials, (success)=>{console.log("Credentials saved Successfully")}, (error)=>{console.log("Error in saving credentials")});
 				cookies.remove(DROPBOX_NAME);
 				cookies.remove(GOOGLEDRIVE_NAME);
 

--- a/src/main/react-front-end/src/views/Login/UserAccountComponent.js
+++ b/src/main/react-front-end/src/views/Login/UserAccountComponent.js
@@ -154,7 +154,10 @@ export default class UserAccountComponent extends Component {
 					});
 					credentials.push(...dropBoxCredentials);
 				}
-				saveOAuthCredentials(credentials, (success)=>{console.log("Credentials saved Successfully")}, (error)=>{console.log("Error in saving credentials")});
+				saveOAuthCredentials(credentials, (success)=>{console.log("Credentials saved Successfully")}, (error)=>{
+					console.log("Error in saving credentials", error);
+					eventEmitter.emit("errorOccured", "Error in saving credentials. You might have to re-authenticate your accounts" );
+				});
 				cookies.remove(DROPBOX_NAME);
 				cookies.remove(GOOGLEDRIVE_NAME);
 


### PR DESCRIPTION
Persist OAuth tokens to DB as soon as the user prefers to do so. Does not require User to go through the OAuth process again for the accounts he is already connected to. 