### PR TITLE
Fixed downloads with space in the name

### DIFF
--- a/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
+++ b/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
@@ -316,8 +316,9 @@ public class VfsResource extends Resource<VfsSession, VfsResource> {
         String filename = strings[strings.length - 1];
         InputStreamResource inputStreamResource = new InputStreamResource(inputStream);
         HttpHeaders httpHeaders = new HttpHeaders();
+
         httpHeaders.set(HttpHeaders.CONTENT_DISPOSITION,
-                "attachment; filename=" + filename);
+                "attachment; filename=\"" + filename + "\"");
         return Mono.just(ResponseEntity.ok()
                 .headers(httpHeaders)
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)


### PR DESCRIPTION
Fixed downloads with spaces in the name. Now, the file name doesn't get truncated after space.