### PR TITLE
fixed largefile transfer for ftp & googledrive

### DIFF
--- a/src/main/java/org/onedatashare/server/module/googledrive/GoogleDriveResource.java
+++ b/src/main/java/org/onedatashare/server/module/googledrive/GoogleDriveResource.java
@@ -16,6 +16,7 @@ import java.io.*;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -354,7 +355,7 @@ public class GoogleDriveResource extends Resource<GoogleDriveSession, GoogleDriv
                         }
                     } else {
                         try {
-                            httpRequestGet.getHeaders().setRange("bytes=" + state + "-" + (state + size - state - 1));
+                            httpRequestGet.getHeaders().setRange("bytes=" + state + "-" + (size - 1));
                             com.google.api.client.http.HttpResponse response = httpRequestGet.execute();
                             InputStream is = response.getContent();
                             IOUtils.copy(is, outputStream);

--- a/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
+++ b/src/main/java/org/onedatashare/server/module/vfs/VfsResource.java
@@ -206,7 +206,7 @@ public class VfsResource extends Resource<VfsSession, VfsResource> {
             }
             InputStream finalInputStream = inputStream;
             return Flux.generate(
-                    () -> 0,
+                    () -> 0L,
                     (state, sink) -> {
                         if (state + sliceSizeInt < size) {
                             byte[] b = new byte[sliceSizeInt];


### PR DESCRIPTION
Fixed largefile transfer for ftp -> ftp (Tested 10gb)
Fixed largefile transfer for ftp -> googledrive (Tested 10gb)
Fixed largefile transfer for googledrive -> googledrive (Tested 10gb)