### PR TITLE
Jobsequencefix

### DIFF
--- a/src/main/java/org/onedatashare/server/model/core/Job.java
+++ b/src/main/java/org/onedatashare/server/model/core/Job.java
@@ -63,6 +63,9 @@ public class Job {
     status = JobStatus.scheduled;
   }
 
+  /*
+   * Constructor created to undertake jobID (thread-safe) as parameter
+   */
   public Job(UserActionResource src, UserActionResource dest, int jobId) {
     uuid();
     setJob_id(jobId);

--- a/src/main/java/org/onedatashare/server/model/core/Job.java
+++ b/src/main/java/org/onedatashare/server/model/core/Job.java
@@ -63,6 +63,15 @@ public class Job {
     status = JobStatus.scheduled;
   }
 
+  public Job(UserActionResource src, UserActionResource dest, int jobId) {
+    uuid();
+    setJob_id(jobId);
+    setSrc(src);
+    setDest(dest);
+    setBytes(new TransferInfo());
+    status = JobStatus.scheduled;
+  }
+
   public Job updateJobWithTransferInfo(TransferInfo info) {
     setBytes(info);
     return this;

--- a/src/main/java/org/onedatashare/server/model/core/JobSequence.java
+++ b/src/main/java/org/onedatashare/server/model/core/JobSequence.java
@@ -1,0 +1,15 @@
+package org.onedatashare.server.model.core;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "jobsequences")
+@Data
+public class JobSequence {
+
+    @Id
+    private String userId;
+
+    private int jobSequence;
+}

--- a/src/main/java/org/onedatashare/server/model/core/User.java
+++ b/src/main/java/org/onedatashare/server/model/core/User.java
@@ -1,16 +1,15 @@
 package org.onedatashare.server.model.core;
 
 import lombok.Data;
+import org.onedatashare.module.globusapi.EndPoint;
 import org.onedatashare.server.model.util.Util;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.net.IDN;
 import java.net.URI;
-import java.security.*;
-
-import org.onedatashare.module.globusapi.EndPoint;
-
+import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.util.*;
 
 @Data
@@ -175,7 +174,10 @@ public class User {
             job.uuid();
         }
         job.setOwner(normalizedEmail());
-        job.setJob_id(jobs.size() + 1);
+        if(job.getJob_id()<1)
+        {
+            job.setJob_id(jobs.size() + 1);
+        }
         jobs.add(job.getUuid());
         return job;
     }

--- a/src/main/java/org/onedatashare/server/service/SequenceGeneratorService.java
+++ b/src/main/java/org/onedatashare/server/service/SequenceGeneratorService.java
@@ -1,0 +1,34 @@
+package org.onedatashare.server.service;
+
+import org.onedatashare.server.model.core.JobSequence;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+import static org.springframework.data.mongodb.core.FindAndModifyOptions.options;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+
+@Service
+public class SequenceGeneratorService {
+
+
+    private MongoOperations mongoOperations;
+
+    @Autowired
+    public SequenceGeneratorService(MongoOperations mongoOperations) {
+        this.mongoOperations = mongoOperations;
+    }
+
+    public int generateSequence(String userId) {
+
+        JobSequence counter = mongoOperations.findAndModify(query(where("userId").is(userId)),
+                new Update().inc("jobSequence",1), options().returnNew(true).upsert(true),
+                JobSequence.class);
+        return !Objects.isNull(counter) ? counter.getJobSequence() : 1;
+
+    }
+}

--- a/src/main/java/org/onedatashare/server/service/SequenceGeneratorService.java
+++ b/src/main/java/org/onedatashare/server/service/SequenceGeneratorService.java
@@ -23,6 +23,15 @@ public class SequenceGeneratorService {
         this.mongoOperations = mongoOperations;
     }
 
+    /**
+     *
+     * @param userId (user unique id which is userService.getEmail()
+     * @return unique sequence id fetched from jobSequences collection w.r.t a user id
+     * findAndModify is an atomic function (thread-safe)
+     *
+     * this function fetches the jobsequence(total number of jobs) and increment the value by 1 corresponding to userID
+     * if exists else it returns and update the jobsequence as 1
+     */
     public int generateSequence(String userId) {
 
         JobSequence counter = mongoOperations.findAndModify(query(where("userId").is(userId)),


### PR DESCRIPTION
Fixed the Job sequencing number. Now, its thread-safe and works fine when multiple jobs are performed parallelly.

P.S. DB entries need to be made in jobsequences collection for existing user jobs.