### PR TITLE
CSS Padding Issue Fix

### DIFF
--- a/src/main/react-front-end/src/App.css
+++ b/src/main/react-front-end/src/App.css
@@ -59,10 +59,10 @@
 /***************************/
 
 .content {
+  padding-top: 10vh;
 }
 
-.underNav {
-  /*padding: 7vh 15vw 3vh;*/
+.navbar {
 }
 
 button.defaultButton {
@@ -81,6 +81,7 @@ button.defaultButton {
 div.homePage {
   /*background: #579;*/
   overflow: hidden;
+  margin-top: -10vh;
 }
 
 .evenSlice {

--- a/src/main/react-front-end/src/views/HomePageComponent.js
+++ b/src/main/react-front-end/src/views/HomePageComponent.js
@@ -57,7 +57,7 @@ export default class HomePageComponent extends Component {
 
 		return(
 			<div>
-				<div className='homePage underNav'>
+				<div className='homePage'>
 
 					<TitleSlice />
 


### PR DESCRIPTION
# CSS Padding Issue

## The Problem
Currently there is a class, `.content`, being used to create a global padding to make room for the navbar. Having this padding for the `HomePageComponent` causes there to be a white bar under the navbar.

## Solution
Right now there's a "hack" way to get around the content padding by using a negative margin.  As the pages are reconstructed, this `.content` padding should no longer be used so that full color backgrounds can be used on any page without a top white bar of empty space.