### PR TITLE
Hotfix: Triple Transfer Rendering 

### DIFF
--- a/src/main/react-front-end/src/views/Transfer/TransferComponent.js
+++ b/src/main/react-front-end/src/views/Transfer/TransferComponent.js
@@ -1,16 +1,16 @@
 /**
  ##**************************************************************
  ##
- ## Copyright (C) 2018-2020, OneDataShare Team, 
+ ## Copyright (C) 2018-2020, OneDataShare Team,
  ## Department of Computer Science and Engineering,
  ## University at Buffalo, Buffalo, NY, 14260.
- ## 
+ ##
  ## Licensed under the Apache License, Version 2.0 (the "License"); you
  ## may not use this file except in compliance with the License.  You may
  ## obtain a copy of the License at
- ## 
+ ##
  ##    http://www.apache.org/licenses/LICENSE-2.0
- ## 
+ ##
  ## Unless required by applicable law or agreed to in writing, software
  ## distributed under the License is distributed on an "AS IS" BASIS,
  ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -178,24 +178,24 @@ export default class TransferComponent extends Component {
   _returnBrowseComponent1() {
     const { mode1, endpoint1, history, compact } = this.state;
     return <BrowseModuleComponent
-      id="browserleft"
-      mode={mode1}
-      endpoint={endpoint1}
-      history={history}
-      displayStyle={compact ? "compact" : "comfort"}
-      update={this.updateBrowseOne} />
+        id="browserleft"
+        mode={mode1}
+        endpoint={endpoint1}
+        history={history}
+        displayStyle={compact ? "compact" : "comfort"}
+        update={this.updateBrowseOne} />
   }
 
   _returnBrowseComponent2() {
     const { mode2, endpoint2, history, compact } = this.state;
 
     return <BrowseModuleComponent
-      id="browserright"
-      mode={mode2}
-      endpoint={endpoint2}
-      history={history}
-      displayStyle={compact ? "compact" : "comfort"}
-      update={this.updateBrowseTwo}
+        id="browserright"
+        mode={mode2}
+        endpoint={endpoint2}
+        history={history}
+        displayStyle={compact ? "compact" : "comfort"}
+        update={this.updateBrowseTwo}
     />
   }
 
@@ -221,7 +221,7 @@ export default class TransferComponent extends Component {
     var task = JSON.parse(start.draggableId.slice(start.draggableId.indexOf(" ")));
     var selectedSide = start.source.droppableId;
     const selected = getSelectedTasks()[selectedSide].find(
-      (listTask) => listTask.name === task.name,
+        (listTask) => listTask.name === task.name,
     );
 
     // if dragging an item that is not selected - unselect all items
@@ -311,9 +311,9 @@ export default class TransferComponent extends Component {
         <FormControl component="fieldset" style={formStyle}>
           <FormLabel component="legend" style={formlabelstyle}>Optimization</FormLabel>
           <RadioGroup
-            aria-label="Optimization"
-            value={this.state.settings.optimizer}
-            onChange={handleChange("optimizer")}
+              aria-label="Optimization"
+              value={this.state.settings.optimizer}
+              onChange={handleChange("optimizer")}
           >
             <FormControlLabel value="None" control={<Radio />} label="None" />
             <FormControlLabel value="2nd Order" control={<Radio />} label="2nd Order" />
@@ -324,9 +324,9 @@ export default class TransferComponent extends Component {
         <FormControl component="fieldset" style={formStyle}>
           <FormLabel component="legend" style={formlabelstyle}>Overwrite</FormLabel>
           <RadioGroup
-            aria-label="Overwrite"
-            value={this.state.settings.overwrite}
-            onChange={handleChange("overwrite")}
+              aria-label="Overwrite"
+              value={this.state.settings.overwrite}
+              onChange={handleChange("overwrite")}
           >
             <FormControlLabel value="true" control={<Radio />} label="True" />
             <FormControlLabel value="false" control={<Radio />} label="False" />
@@ -335,9 +335,9 @@ export default class TransferComponent extends Component {
         <FormControl component="fieldset" style={formStyle}>
           <FormLabel component="legend" style={formlabelstyle}>Integrity</FormLabel>
           <RadioGroup
-            aria-label="Integrity"
-            value={this.state.settings.verify}
-            onChange={handleChange("verify")}
+              aria-label="Integrity"
+              value={this.state.settings.verify}
+              onChange={handleChange("verify")}
           >
             <FormControlLabel value="true" control={<Radio />} label="True" />
             <FormControlLabel value="false" control={<Radio />} label="False" />
@@ -347,9 +347,9 @@ export default class TransferComponent extends Component {
         <FormControl component="fieldset" style={formStyle}>
           <FormLabel component="legend" style={formlabelstyle}>Encrypt</FormLabel>
           <RadioGroup
-            aria-label="Encrypt"
-            value={this.state.settings.encrypt}
-            onChange={handleChange("encrypt")}
+              aria-label="Encrypt"
+              value={this.state.settings.encrypt}
+              onChange={handleChange("encrypt")}
           >
             <FormControlLabel value="true" control={<Radio />} label="True" />
             <FormControlLabel value="false" control={<Radio />} label="False" />
@@ -359,9 +359,9 @@ export default class TransferComponent extends Component {
         <FormControl component="fieldset" style={formStyle}>
           <FormLabel component="legend" style={formlabelstyle}>Compress</FormLabel>
           <RadioGroup
-            aria-label="Compress"
-            value={this.state.settings.compress}
-            onChange={handleChange("compress")}
+              aria-label="Compress"
+              value={this.state.settings.compress}
+              onChange={handleChange("compress")}
           >
             <FormControlLabel value="true" control={<Radio />} label="True" />
             <FormControlLabel value="false" control={<Radio />} label="False" />
@@ -372,11 +372,11 @@ export default class TransferComponent extends Component {
           <FormLabel component="legend" style={formlabelstyle}>Retry Counts</FormLabel>
           <Slider
 
-            value={this.state.settings.retry}
-            min={0}
-            max={10}
-            step={1}
-            onChange={handleChangeRetry}
+              value={this.state.settings.retry}
+              min={0}
+              max={10}
+              step={1}
+              onChange={handleChangeRetry}
           />
           <FormLabel style={{ marginTop: "20px", fontSize: "20px" }}>{this.state.settings.retry} Times</FormLabel>
         </FormControl>
@@ -398,183 +398,80 @@ export default class TransferComponent extends Component {
       let compactViewEnabled = event.target.checked;
       let email = store.getState().email;
       updateViewPreference(email, compactViewEnabled,
-        (success) => {
-          console.log("Compact View Preference Switched Succesfully", success);
-          store.dispatch(compactViewPreference(compactViewEnabled));
-        },
-        (error) => { console.log("ERROR in updation" + error) }
+          (success) => {
+            console.log("Compact View Preference Switched Succesfully", success);
+            store.dispatch(compactViewPreference(compactViewEnabled));
+          },
+          (error) => { console.log("ERROR in updation" + error) }
       );
     };
 
     return (
-      <div style={{ display: "flex", flexDirection: 'row', justifyContent: 'center' }}>
-        <Col xs={11} style={{ display: "flex", justifyContent: 'center', flexDirection: 'column' }}>
+        <div style={{ display: "flex", flexDirection: 'row', justifyContent: 'center' }}>
+          <Col xs={11} style={{ display: "flex", justifyContent: 'center', flexDirection: 'column' }}>
 
-          {!isSmall &&
+            {!isSmall &&
             <Panel bsStyle="primary">
               <FormControlLabel
-                style={{ width: "200px", right: "10px", color: "white", position: "absolute" }}
-                control={
-                  <Switch
-                    color="default"
-                    style={{ colorPrimary: "white", colorSecondary: "white" }}
-                    checked={this.state.compact}
-                    onChange={updateCompactViewPreference('compact')}
-                    value="compact"
-                  />
-                }
-                label={<Typography style={{ color: "white", fontSize: "12px" }}>Compact</Typography>}
+                  style={{ width: "200px", right: "10px", color: "white", position: "absolute" }}
+                  control={
+                    <Switch
+                        color="default"
+                        style={{ colorPrimary: "white", colorSecondary: "white" }}
+                        checked={this.state.compact}
+                        onChange={updateCompactViewPreference('compact')}
+                        value="compact"
+                    />
+                  }
+                  label={<Typography style={{ color: "white", fontSize: "12px" }}>Compact</Typography>}
               />
               <Panel.Heading>
                 <div style={headerStyle}>
                   <p>
                     Browse and Transfer Files
-              </p>
-            </div>
-          </Panel.Heading>
+                  </p>
+                </div>
+              </Panel.Heading>
 
-          <Panel.Body key={isSmall} style={{overflow: "hidden"}}>
-            <Row style={{flexDirection: 'column'}} key="browseComponents">
-              <DragDropContext
-                onDragStart={this.onDragStart}
-                onDragEnd={this.onDragEnd}>
-                <Col xs={6} style={panelStyle}  >
-                  {this._returnBrowseComponent1()}
-                </Col>
-                <Col xs={6} style={panelStyle} >
-                  {this._returnBrowseComponent2()}
-                </Col>
-              </DragDropContext>
-            </Row>
-            <Row style={{display: 'block', ...headerStyle}} key="sendButtons">
-                <Button id="sendFromRightToLeft" style={{padding: '15px', marginRight: '10px'}} onClick={this.onSendToLeft}> <Glyphicon glyph="arrow-left" />    Send</Button>
-                <Button id="sendFromLeftToRight" style={{padding: '15px', marginLeft: '10px'}} onClick={this.onSendToRight}> Send<Glyphicon glyph="arrow-right" /></Button>
-            </Row>
-
-            <ErrorMessagesConsole/>
-          </Panel.Body>
-          </Panel>
-
-
-        }
-        {/* !isSmall && this.getSettingComponent(isSmall) */}
-        {isSmall &&
-        <Panel bsStyle="primary">
-        <Panel.Heading style={{ textAlign: "center" }}>
-          <p>
-            Browse and Transfer Files
-          </p>
-
-          { /* Disabling compact mode toggle for mobile screens */
-            /* <FormControlLabel
-            style={{ color: "white" }}
-            control={
-              <Switch
-                color="default"
-                style={{colorPrimary: "white", colorSecondary:"white"}}
-                checked={this.state.compact}
-                onChange={updateCompactViewPreference('compact')}
-                value="compact"
-              />
-            }
-            label={<Typography style={{fontSize: "12px"}}>Compact</Typography>}
-          /> */}
-        </Panel.Heading>
-
-
-        <Panel.Body key={isSmall} style={{overflow: "hidden"}}>
-            <Row style={{flexDirection: 'column'}}>
-              <DragDropContext
-                  onDragStart={this.onDragStart}
-                  onDragEnd={this.onDragEnd}
-              >
-                <Col style={panelStyle}>
-                  {this._returnBrowseComponent1()}
-                </Col>
-                <Row style={{display: 'flex', flexDirection: 'row', justifyContent: 'center' }}>
-                  <Button id="sendFromRightToLeft" style={{padding: '15px', marginRight: '10px'}} onClick={this.onSendToLeft}> <Glyphicon glyph="arrow-up" /> Send</Button>
-                  <Button id="sendFromLeftToRight" style={{padding: '15px', marginLeft: '10px'}} onClick={this.onSendToRight}> Send<Glyphicon glyph="arrow-down" /></Button>
+              <Panel.Body key={isSmall} style={{overflow: "hidden"}}>
+                <Row style={{flexDirection: 'column'}} key="browseComponents">
+                  <DragDropContext
+                      onDragStart={this.onDragStart}
+                      onDragEnd={this.onDragEnd}>
+                    <Col xs={6} style={panelStyle}  >
+                      {this._returnBrowseComponent1()}
+                    </Col>
+                    <Col xs={6} style={panelStyle} >
+                      {this._returnBrowseComponent2()}
+                    </Col>
+                  </DragDropContext>
                 </Row>
-                <Row style={{ display: 'block', ...headerStyle }}>
-                  <Button id="sendFromRightToLeft" style={{ padding: '15px', marginRight: '10px' }} onClick={this.onSendToLeft}> <Glyphicon glyph="arrow-left" />    Send</Button>
-                  <Button id="sendFromLeftToRight" style={{ padding: '15px', marginLeft: '10px' }} onClick={this.onSendToRight}> Send<Glyphicon glyph="arrow-right" /></Button>
+                <Row style={{display: 'block', ...headerStyle}} key="sendButtons">
+                  <Button id="sendFromRightToLeft" style={{padding: '15px', marginRight: '10px'}} onClick={this.onSendToLeft}> <Glyphicon glyph="arrow-left" />    Send</Button>
+                  <Button id="sendFromLeftToRight" style={{padding: '15px', marginLeft: '10px'}} onClick={this.onSendToRight}> Send<Glyphicon glyph="arrow-right" /></Button>
                 </Row>
 
-                <ErrorMessagesConsole />
-              </DragDropContext>
-              </Row>
+                <ErrorMessagesConsole/>
               </Panel.Body>
             </Panel>
 
 
-          }
-          {/* !isSmall && this.getSettingComponent(isSmall) */}
-          {isSmall &&
+            }
+            {/* !isSmall && this.getSettingComponent(isSmall) */}
+            {isSmall &&
             <Panel bsStyle="primary">
-              <Panel.Heading style={{ textAlign: "center" }}>
-                <p>
-                  Browse and Transfer Files
-          </p>
-
-                <FormControlLabel
-                  style={{ color: "white" }}
+              <FormControlLabel
+                  style={{ width: "200px", float: "right", color: "white" }}
                   control={
                     <Switch
-                      color="default"
-                      style={{ colorPrimary: "white", colorSecondary: "white" }}
-                      checked={this.state.compact}
-                      onChange={updateCompactViewPreference('compact')}
-                      value="compact"
+                        color="default"
+                        style={{ colorPrimary: "white", colorSecondary: "white" }}
+                        checked={this.state.compact}
+                        onChange={handleChange('compact')}
+                        value="compact"
                     />
                   }
                   label={<Typography style={{ fontSize: "12px" }}>Compact</Typography>}
-                />
-              </Panel.Heading>
-
-
-              <Panel.Body key={isSmall} style={{ overflow: "hidden" }}>
-                <Row style={{ flexDirection: 'column' }}>
-                  <DragDropContext
-                    onDragStart={this.onDragStart}
-                    onDragEnd={this.onDragEnd}
-                  >
-                    <Col style={panelStyle}>
-                      {this._returnBrowseComponent1()}
-                    </Col>
-                    <Row style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center' }}>
-                      <Button id="sendFromRightToLeft" style={{ padding: '15px', marginRight: '10px' }} onClick={this.onSendToLeft}> <Glyphicon glyph="arrow-up" /> Send</Button>
-                      <Button id="sendFromLeftToRight" style={{ padding: '15px', marginLeft: '10px' }} onClick={this.onSendToRight}> Send<Glyphicon glyph="arrow-down" /></Button>
-                    </Row>
-                    <Row style={panelStyle}>
-                      {this._returnBrowseComponent2()}
-                    </Row>
-
-                    {/*  <Row> {this.getSettingComponent(isSmall)} </Row> */}
-                  </DragDropContext>
-
-                </Row>
-                <div> </div>
-                <ErrorMessagesConsole />
-              </Panel.Body>
-            </Panel>
-
-
-          }
-          {/* !isSmall && this.getSettingComponent(isSmall) */}
-          {isSmall &&
-            <Panel bsStyle="primary">
-              <FormControlLabel
-                style={{ width: "200px", float: "right", color: "white" }}
-                control={
-                  <Switch
-                    color="default"
-                    style={{ colorPrimary: "white", colorSecondary: "white" }}
-                    checked={this.state.compact}
-                    onChange={handleChange('compact')}
-                    value="compact"
-                  />
-                }
-                label={<Typography style={{ fontSize: "12px" }}>Compact</Typography>}
               />
               <Panel.Heading>
                 <p>
@@ -583,8 +480,8 @@ export default class TransferComponent extends Component {
               <Panel.Body key={isSmall} style={{ overflow: "hidden" }}>
                 <Row style={{ flexDirection: 'column' }}>
                   <DragDropContext
-                    onDragStart={this.onDragStart}
-                    onDragEnd={this.onDragEnd}
+                      onDragStart={this.onDragStart}
+                      onDragEnd={this.onDragEnd}
                   >
                     <Col style={panelStyle}>
                       {this._returnBrowseComponent1()}
@@ -602,8 +499,8 @@ export default class TransferComponent extends Component {
                 <ErrorMessagesConsole />
               </Panel.Body>
             </Panel>}
-        </Col>
-      </div>
+          </Col>
+        </div>
     );
   }
 }


### PR DESCRIPTION
The transfer page currently has 3 transfer components rendered on a mobile view. Now fixed with the panels with endpoints selection stacked on top of each other and the response window below them. 

![mobile transfer](https://user-images.githubusercontent.com/22754601/78201909-d9eb9980-7460-11ea-8816-e9c14a7355d1.png)
