### PR TITLE
Updated OauthEndpointCredential Object.

### DIFF
--- a/src/main/java/org/onedatashare/server/service/oauth/GDriveOauthService.java
+++ b/src/main/java/org/onedatashare/server/service/oauth/GDriveOauthService.java
@@ -108,7 +108,8 @@ public class GDriveOauthService {
                 OAuthEndpointCredential credential  = new OAuthEndpointCredential(userId)
                         .setToken(response.getAccessToken())
                         .setRefreshToken(response.getRefreshToken())
-                        .setExpiresAt(calendar.getTime());
+                        .setExpiresAt(calendar.getTime())
+                        .setTokenExpires(true);
                 s.success(credential);
             } catch (IOException | GeneralSecurityException e) {
                 s.error(e);


### PR DESCRIPTION
Updated OauthEndpointCredential Object for gdrive and dropbox to
- manage and save refresh_token for dropbox
- set tokenExpires property to true (gdrive and dropbox)