### PR TITLE
Fix for issue 378 | DropBox OAuth credential creation 

### DIFF
--- a/src/main/java/org/onedatashare/server/service/oauth/DbxOauthService.java
+++ b/src/main/java/org/onedatashare/server/service/oauth/DbxOauthService.java
@@ -27,6 +27,8 @@ import com.dropbox.core.*;
 import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.v2.users.FullAccount;
 import org.onedatashare.server.model.credential.OAuthEndpointCredential;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -52,6 +54,7 @@ public class DbxOauthService  {
     private DbxWebAuth auth;
     private String token = null;
 
+    private static final Logger LOG = LoggerFactory.getLogger(DbxOauthService.class);
     private static final String STATE = "state", CODE = "code";
 
     @PostConstruct
@@ -62,16 +65,18 @@ public class DbxOauthService  {
             public void clear() { set(null); }
             public String get() { return token; }
             public void set(String s) {
-                token = s;
+                if(s!=null)
+                    token = s;
             }
         };
         auth = new DbxWebAuth(config, secrets);
     }
 
     public String start(){
-        return auth.authorize(DbxWebAuth
+    	return auth.authorize(DbxWebAuth
                 .Request
                 .newBuilder()
+                .withTokenAccessType(TokenAccessType.OFFLINE)
                 .withRedirectUri(dbxConfig.getRedirectUri(), sessionStore)
                 .build());
     }

--- a/src/main/java/org/onedatashare/server/service/oauth/GDriveOauthService.java
+++ b/src/main/java/org/onedatashare/server/service/oauth/GDriveOauthService.java
@@ -108,7 +108,8 @@ public class GDriveOauthService {
                 OAuthEndpointCredential credential  = new OAuthEndpointCredential(userId)
                         .setToken(response.getAccessToken())
                         .setRefreshToken(response.getRefreshToken())
-                        .setExpiresAt(calendar.getTime());
+                        .setExpiresAt(calendar.getTime())
+                        .setTokenExpires(true);
                 s.success(credential);
             } catch (IOException | GeneralSecurityException e) {
                 s.error(e);


### PR DESCRIPTION
Added
 -  missing null check
 -  set token access type to OFFLINE to get both short-lived tokens

also, updated the dbx credentials on one of the node