### PR TITLE
pagination bugfix for Job History

### DIFF
--- a/src/main/react-front-end/src/utils.js
+++ b/src/main/react-front-end/src/utils.js
@@ -23,13 +23,12 @@
 
 export function humanReadableSpeed(size) {
 	if (size < 1024) 
-		return parseFloat(size.toFixed(4)) + ' Mb/s';
+		return parseFloat(size.toFixed(2)) + ' Mb/s';
     let i = Math.floor(Math.log(size) / Math.log(1024));
 	let num = (size / Math.pow(1024, i));
     let round = Math.round(num);
     num = round < 10 ? num.toFixed(2) : round < 100 ? num.toFixed(1) : round;
     num = num*(1);
     num = parseFloat(num.toFixed(4));
-    console.log("num",num);
     return `${num} ${'KMGTPEZY'[i]}b/s`
 }

--- a/src/main/react-front-end/src/views/JobHistory/JobHistoryComponent.js
+++ b/src/main/react-front-end/src/views/JobHistory/JobHistoryComponent.js
@@ -107,24 +107,12 @@
 		//success
 		//let responsesToDisplay = this.paginateResults(resp.jobs, page, rowsPerPage);
 		//commented to fix second page render issue as it slices all jobs and returns null object
-		
-		// Temporary boolean to check for duplicates changes on backend required
-		let itemsInList = []
-		let dupRemoval = []
-		resp.content.forEach(item => {
-			if (!itemsInList.includes(item.id)) {
-				dupRemoval.push(item)
-				itemsInList.push(item.id)
-			}
-		})
-
 		this.setState({
 			response: resp.content,
-			responsesToDisplay: dupRemoval,
-			totalCount: itemsInList.length,
+			responsesToDisplay: resp.content,
+			totalCount: resp.totalElements,
 			loading: false
 		});
-		this.update();
 	}
 
 	queueFuncFail(resp) {

--- a/src/main/react-front-end/src/views/JobHistory/QueueTableRow/RowElement/RowElement.js
+++ b/src/main/react-front-end/src/views/JobHistory/QueueTableRow/RowElement/RowElement.js
@@ -21,6 +21,7 @@ export default class RowElement extends React.Component {
           expanded: true,
         };
         this.handleToggle = this.handleToggle.bind(this);
+        this.formatBytes = this.formatBytes.bind(this);
     }
     infoRow() {
         return (
@@ -37,11 +38,32 @@ export default class RowElement extends React.Component {
         }));
     }
 
-    // Finds time difference  between two dates in ISO 1082 format
+    // Finds time difference between two dates in ISO 1082 format
     findTimeDiff(startTime, endTime) {
         let diff = new Date(endTime) - new Date(startTime)
         return `${diff / 1000}s`
     }
+
+    // This function formats bytes takes in an input of bytes and returns a string rounding to the nearest 3 digit integer
+    // Input: Integer of Bytes
+    // Output: Formatted string for table
+    formatBytes(bytes) {
+        let result = bytes
+        try {
+            result = parseFloat(result)
+        }
+        catch (err) {
+            console.error(err)
+        }
+        const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        let unitIndex = 0;
+        while (result >= 1024 && unitIndex < units.length - 1) {
+            result /= 1024;
+            unitIndex++;
+        }
+        return result.toFixed(2) + ' ' + units[unitIndex];
+    }
+    
 
     renderActions(owner, jobID, status, deleted) {
         const {infoButtonOnClick, cancelButtonOnClick, restartButtonOnClick, deleteButtonOnClick} = this.props
@@ -75,7 +97,6 @@ export default class RowElement extends React.Component {
     }
     render() {
         const {resp, infoVisible} = this.props
-        let bar = (<QueueProgressBar status={resp.status} total={resp.jobParameters.jobSize} done={resp.jobParameters.jobSize}/>);
         let difference = (Date.parse(resp.endTime) - Date.parse(resp.startTime))/1000;
         let speed = parseFloat((resp.jobParameters.jobSize/1000000)*8)/(difference);
         if (isNaN(speed))
@@ -142,13 +163,12 @@ export default class RowElement extends React.Component {
                                 <p>{resp.jobParameters.destCredentialType}</p>
                             </TableCell>
                             <TableCell className={"jobSizeCell" + " queueBodyCell"}>
-                                <p>{resp.jobParameters.jobSize}</p>
+                                <p>{this.formatBytes(resp.jobParameters.jobSize)}</p>
                             </TableCell>
                     </Hidden>
                     <Hidden lgUp>
                         <TableCell className="mobileCell">
                             <p><b>Job ID:</b> {resp.id}</p>
-                            <p><b>Progress: </b>{bar}</p>
                             <p><b>Average Speed:</b> {humanReadableSpeed(speed)}</p>
                             <p><b>Source:</b> {resp.jobParameters.sourceBasePath}</p>
                             <p><b>Destination:</b>{resp.jobParameters.destBasePath}</p>

--- a/src/main/react-front-end/src/views/JobHistory/QueueTableRow/RowElement/RowElement.js
+++ b/src/main/react-front-end/src/views/JobHistory/QueueTableRow/RowElement/RowElement.js
@@ -45,8 +45,8 @@ export default class RowElement extends React.Component {
     }
 
     // This function formats bytes takes in an input of bytes and returns a string rounding to the nearest 3 digit integer
-    // Input: Integer of Bytes
-    // Output: Formatted string for table
+    // Input: number of bytes
+    // Output: Formatted string for jobSize column in table
     formatBytes(bytes) {
         let result = bytes
         try {


### PR DESCRIPTION
Removed the duplicate removal function since it is now fixed in the backend. Also fixed pagination in history page.

Further formatting fixes have been made to:
- Speed column in queue page
- Job size in history page